### PR TITLE
fix(python): skip global env setup when python chaser is disabled

### DIFF
--- a/lua/chase/init.lua
+++ b/lua/chase/init.lua
@@ -746,7 +746,11 @@ vim.api.nvim_create_autocmd("VimEnter", {
         vim.api.nvim_set_hl(0, "ChaseFile",   { link = "Directory", default = true })
         vim.api.nvim_set_hl(0, "ChaseInfo",   { link = "Comment",   default = true })
         M.vim_did_enter = true
-        M.setup_virtualenv("chase_global", M.set_python_global)
+        if M.config.chasers.python and M.config.chasers.python.enabled then
+            M.setup_virtualenv("chase_global", M.set_python_global)
+        else
+            M.global_env_done = true
+        end
         M.refresh()
     end,
     group = M.group,


### PR DESCRIPTION
## Problem

`setup_virtualenv("chase_global", ...)` was called unconditionally on `VimEnter`, even when the Python chaser was disabled in config. This caused unnecessary virtualenv creation (and potential failures) on machines where Python was not needed.

## Solution

Gate the global env setup behind `config.chasers.python and config.chasers.python.enabled`. When Python is disabled, `global_env_done` is set to `true` immediately so any downstream `until_true` waiters do not hang.

```lua
-- before
M.setup_virtualenv("chase_global", M.set_python_global)

-- after
if M.config.chasers.python and M.config.chasers.python.enabled then
    M.setup_virtualenv("chase_global", M.set_python_global)
else
    M.global_env_done = true
end
```

## Testing

1. Set `chasers = { python = { enabled = false } }` in your chase `setup()` call.
2. Open Neovim — no virtualenv should be created under `venvs_dir/chase_global_env`.
3. Set `enabled = true` and confirm the global env is created as before.

Closes #4.