### PR TITLE
fix(python): move uv job callbacks from on_stdout to on_exit

### DIFF
--- a/lua/chase/init.lua
+++ b/lua/chase/init.lua
@@ -496,16 +496,14 @@ function M.setup_virtualenv(venv_prefix, callback)
         vim.fn.jobstart(
         M.get_virtualenv_job(venv_path.filename),
         {
-            stdout_buffered = true,
-            on_stdout = function(_, _)
-                M.log.warn("virtualenv " .. venv_prefix .. " created successfully")
-                if callback ~= nil then
-                    callback(venv_path)
-                end
-            end,
             on_exit = function(_, exit_code)
                 if exit_code ~= 0 then
                     M.log.error("Failed to create virtualenv for " .. venv_prefix .. " with error: " .. exit_code)
+                    return
+                end
+                M.log.warn("virtualenv " .. venv_prefix .. " created successfully")
+                if callback ~= nil then
+                    callback(venv_path)
                 end
             end,
         })
@@ -562,12 +560,18 @@ function M.install_package(venv_path, package, install)
                 vim.fn.jobstart(
                 M.get_pip_command("install", install),
                 {
-                    stdout_buffered = true,
-                    on_stdout = function(_,_)
-                        M.log.warn(
-                        package .. " installed at " .. venv_path.filename ..
-                        " successfully"
-                        )
+                    on_exit = function(_, install_code)
+                        if install_code == 0 then
+                            M.log.warn(
+                            package .. " installed at " .. venv_path.filename ..
+                            " successfully"
+                            )
+                        else
+                            M.log.error(
+                            "Failed to install " .. package .. " at " ..
+                            venv_path.filename
+                            )
+                        end
                     end,
                 })
             end


### PR DESCRIPTION
## Problem

`uv` writes all output (including success messages) to **stderr**, not stdout. Both `setup_virtualenv` and `install_package` used `on_stdout` to detect completion, which meant:

- The virtualenv-created callback was silently dropped → `set_python_global` was never called on fresh installs.
- Package install success was never logged; failures were also invisible.

This is the root cause of silent failures during a clean first-run install.

## Solution

Replace `on_stdout` with `on_exit` in both places. Exit code 0 = success; any other code = failure. Explicit error logging added to `install_package` so failures surface in the chase log.

```lua
-- setup_virtualenv: before
on_stdout = function(_, _)
    M.log.warn("virtualenv created")
    if callback ~= nil then callback(venv_path) end
end,
on_exit = function(_, exit_code)
    if exit_code ~= 0 then M.log.error(...) end
end,

-- setup_virtualenv: after
on_exit = function(_, exit_code)
    if exit_code ~= 0 then M.log.error(...) return end
    M.log.warn("virtualenv created")
    if callback ~= nil then callback(venv_path) end
end,
```

## Testing

1. Delete `~/.local/share/nvim/chase/` (or your `venvs_dir`).
2. Open Neovim with the Python chaser enabled.
3. Check the chase log (`stdpath("data")/chase.log`) — you should see "virtualenv chase_global created successfully" and each package install logged.
4. Previously, none of those log lines appeared when uv was the pip backend.

Part of #3.