### PR TITLE
fix(python): pin uv to target venv and wait for all packages before marking env ready

### DIFF
--- a/lua/chase/init.lua
+++ b/lua/chase/init.lua
@@ -496,16 +496,14 @@ function M.setup_virtualenv(venv_prefix, callback)
         vim.fn.jobstart(
         M.get_virtualenv_job(venv_path.filename),
         {
-            stdout_buffered = true,
-            on_stdout = function(_, _)
-                M.log.warn("virtualenv " .. venv_prefix .. " created successfully")
-                if callback ~= nil then
-                    callback(venv_path)
-                end
-            end,
             on_exit = function(_, exit_code)
                 if exit_code ~= 0 then
                     M.log.error("Failed to create virtualenv for " .. venv_prefix .. " with error: " .. exit_code)
+                    return
+                end
+                M.log.warn("virtualenv " .. venv_prefix .. " created successfully")
+                if callback ~= nil then
+                    callback(venv_path)
                 end
             end,
         })
@@ -562,12 +560,18 @@ function M.install_package(venv_path, package, install)
                 vim.fn.jobstart(
                 M.get_pip_command("install", install),
                 {
-                    stdout_buffered = true,
-                    on_stdout = function(_,_)
-                        M.log.warn(
-                        package .. " installed at " .. venv_path.filename ..
-                        " successfully"
-                        )
+                    on_exit = function(_, install_code)
+                        if install_code == 0 then
+                            M.log.warn(
+                            package .. " installed at " .. venv_path.filename ..
+                            " successfully"
+                            )
+                        else
+                            M.log.error(
+                            "Failed to install " .. package .. " at " ..
+                            venv_path.filename
+                            )
+                        end
                     end,
                 })
             end

--- a/lua/chase/init.lua
+++ b/lua/chase/init.lua
@@ -530,27 +530,45 @@ function M.set_python_global(venv_path)
         venv_bin = venv_path:joinpath("Scripts")
         venv_host_prog = venv_bin:joinpath("python.exe")
     end
-    -- local venv_activate = venv_bin:joinpath("activate")
     M.add_to_path(venv_bin)
     vim.cmd("let g:python3_host_prog='" .. venv_host_prog .. "'")
-    M.install_package(venv_path, "build", "build[virtualenv]")
-    M.install_package(venv_path, "pynvim")
-    M.install_package(venv_path, "twine")
-    M.install_package(venv_path, "wheel")
-    M.global_env_done = true
+
+    local global_packages = {
+        { name = "build", install = "build[virtualenv]" },
+        { name = "pynvim" },
+        { name = "twine" },
+        { name = "wheel" },
+    }
+    local pending = #global_packages
+    local function on_package_done()
+        pending = pending - 1
+        if pending == 0 then
+            M.log.warn("global python environment ready")
+            M.global_env_done = true
+        end
+    end
+    for _, pkg in ipairs(global_packages) do
+        M.install_package(venv_path, pkg.name, pkg.install, on_package_done)
+    end
 end
 
-function M.get_pip_command(cmd, package)
+function M.get_pip_command(cmd, package, venv_path)
     if M.uv_installed then
-        return { M.installed_uv, "pip", cmd, package }
+        local base = { M.installed_uv, "pip", cmd, package }
+        if venv_path then
+            -- pin uv to the target venv, ignoring any active VIRTUAL_ENV
+            table.insert(base, "--python")
+            table.insert(base, venv_path:joinpath("bin", M.installed_python).filename)
+        end
+        return base
     end
     return { M.installed_python, "-m", "pip", cmd, package }
 end
 
-function M.install_package(venv_path, package, install)
+function M.install_package(venv_path, package, install, on_done)
     install = install or package
     vim.fn.jobstart(
-    M.get_pip_command("show", package),
+    M.get_pip_command("show", package, venv_path),
     {
         on_exit = function(_, code)
             if code ~= 0 then
@@ -558,7 +576,7 @@ function M.install_package(venv_path, package, install)
                 "installing " .. package .. " at venv " .. venv_path.filename
                 )
                 vim.fn.jobstart(
-                M.get_pip_command("install", install),
+                M.get_pip_command("install", install, venv_path),
                 {
                     on_exit = function(_, install_code)
                         if install_code == 0 then
@@ -572,8 +590,11 @@ function M.install_package(venv_path, package, install)
                             venv_path.filename
                             )
                         end
+                        if on_done then on_done() end
                     end,
                 })
+            else
+                if on_done then on_done() end
             end
         end,
     })


### PR DESCRIPTION
## Problem

Two related async bugs in `set_python_global` / `install_package`:

### Bug 1 — premature `global_env_done` (race condition)

```lua
-- before: flag set synchronously, jobs still running
M.install_package(venv_path, "build", "build[virtualenv]")
M.install_package(venv_path, "pynvim")
M.install_package(venv_path, "twine")
M.install_package(venv_path, "wheel")
M.global_env_done = true   -- ← set before any install finishes
```

Project-venv setup (which waits for `global_env_done`) could start while global packages were still being written, causing partial environments and "packages from global env installed into project venv" symptoms.

### Bug 2 — uv respects `VIRTUAL_ENV` env var

`uv pip install` uses the active `VIRTUAL_ENV` if no explicit target is given. If any virtualenv was activated in the shell before Neovim started, uv would silently install into that venv instead of the intended one.

## Solution

**Bug 1:** Add an `on_done` callback to `install_package`. `set_python_global` uses a pending counter — `global_env_done` is set only when all four `on_done` callbacks have fired.

```lua
local pending = #global_packages
local function on_package_done()
    pending = pending - 1
    if pending == 0 then
        M.log.warn("global python environment ready")
        M.global_env_done = true
    end
end
for _, pkg in ipairs(global_packages) do
    M.install_package(venv_path, pkg.name, pkg.install, on_package_done)
end
```

**Bug 2:** `get_pip_command` accepts a `venv_path` and appends `--python <venv>/bin/python` to every `uv pip` call, ignoring any active `VIRTUAL_ENV`.

## Testing

1. Activate a dummy venv in your shell (`source /tmp/dummy/bin/activate`), then launch Neovim. Before this fix, packages would install into `/tmp/dummy`; after, they install into the chase global env.
2. Check the chase log — the "global python environment ready" message should appear only after all four packages are done, not immediately on VimEnter.
3. Run `pip show pynvim` inside the chase global env to confirm packages landed in the right place.

Closes #2. Together with #4 (PR #43), closes #3.

> **Merge note:** This branch builds on the `on_stdout → on_exit` fix (PR #44). Please merge PR #44 first, then rebase this branch onto master before merging.